### PR TITLE
Create a second post during tests that doesnt purge

### DIFF
--- a/tests/PostCacheCest.php
+++ b/tests/PostCacheCest.php
@@ -13,7 +13,8 @@
 class PostCacheCest
 {
 	// The post id created during tests, and needing cleanup
-	public $post_id;
+	public $post_id_1;
+	public $post_id_2;
 
 	// Use the following data on example post create/update
 	public $post_title = "Cache Test Runner";
@@ -27,25 +28,43 @@ class PostCacheCest
 	{
 		$post['title'] = $this->post_title;
 		$post['content'] = $this->post_content_0;
-		$this->post_id = $I->havePost( $post );
+		$this->post_id_1 = $I->havePost( $post );
+
+		$post['title'] = $this->post_title . ' 2';
+		$post['content'] = $this->post_content_0 . ' 2';
+		$this->post_id_2 = $I->havePost( $post );
 	}
 
 	/**
-	 * Query the specific post and check the cache hit counter
+	 * Query the specific post and check the cache hit counter.
+	 * Use this separate step function because the 'wpe_auth' cookie was present in $I tester and bypasses cache.
 	 */
 	public function VerifySeeCacheHeaderTest( AcceptanceTester $I )
 	{
-		$I->seePostById( $this->post_id );
+		$I->seePostById( $this->post_id_1 );
 		$response = $I->grabDataByPost();
 		$I->assertEquals( $this->post_title, $response['title'] );
 		$I->assertEquals( "<p>{$this->post_content_0}</p>\n", $response['content'] );
 		$I->seeHttpHeader('X-Cache', 'MISS');
 
 		// Query again and see the cached version
-		$I->seePostById( $this->post_id );
+		$I->seePostById( $this->post_id_1 );
 		$response = $I->grabDataByPost();
 		$I->assertEquals( $this->post_title, $response['title'] );
 		$I->assertEquals( "<p>{$this->post_content_0}</p>\n", $response['content'] );
+		$I->seeHttpHeader('X-Cache', 'HIT: 1');
+
+		$I->seePostById( $this->post_id_2 );
+		$response = $I->grabDataByPost();
+		$I->assertEquals( $this->post_title . ' 2', $response['title'] );
+		$I->assertEquals( "<p>{$this->post_content_0} 2</p>\n", $response['content'] );
+		$I->seeHttpHeader('X-Cache', 'MISS');
+
+		// Query again and see the cached version
+		$I->seePostById( $this->post_id_2 );
+		$response = $I->grabDataByPost();
+		$I->assertEquals( $this->post_title . ' 2', $response['title'] );
+		$I->assertEquals( "<p>{$this->post_content_0} 2</p>\n", $response['content'] );
 		$I->seeHttpHeader('X-Cache', 'HIT: 1');
 	}
 
@@ -55,7 +74,7 @@ class PostCacheCest
 	public function UpdateThePostTest( AcceptanceTester $I )
 	{
 		$params['content'] = $this->post_content_1;
-		$I->updatePost( $this->post_id, $params );
+		$I->updatePost( $this->post_id_1, $params );
 	}
 
 	/**
@@ -63,11 +82,18 @@ class PostCacheCest
 	 */
 	public function CheckForCacheMissTest( AcceptanceTester $I )
 	{
-		$I->seePostById( $this->post_id );
+		$I->seePostById( $this->post_id_1 );
 		$I->seeHttpHeader('X-Cache', 'MISS');
 		$response = $I->grabDataByPost();
 		$I->assertEquals( $this->post_title, $response['title'] );
 		$I->assertEquals( "<p>{$this->post_content_1}</p>\n", $response['content'] );
+
+		// Query second post and see the cached version
+		$I->seePostById( $this->post_id_2 );
+		$response = $I->grabDataByPost();
+		$I->assertEquals( $this->post_title . ' 2', $response['title'] );
+		$I->assertEquals( "<p>{$this->post_content_0} 2</p>\n", $response['content'] );
+		$I->seeHttpHeader('X-Cache', 'HIT: 2');
 	}
 
 	public function CleanUpAtTheEnd( AcceptanceTester $I )


### PR DESCRIPTION
Create a second test post.
Query it and verify hit/miss.
Update the first post.
The second (non-updated) post should not update.

Refactor a little of the acceptance helper also.

https://github.com/wp-graphql/wp-graphql-labs/issues/109

<img width="399" alt="Screen Shot 2022-03-24 at 2 36 58 PM" src="https://user-images.githubusercontent.com/749603/159997210-2df8ecbe-22a1-4658-91d2-2191f5844982.png">

