### PR TITLE
Return a unique not real url to prevent unwanted purge all

### DIFF
--- a/wpe-graphql.php
+++ b/wpe-graphql.php
@@ -75,6 +75,11 @@ add_filter( 'wpe_purge_varnish_cache_paths', function ( $paths, $identifier ) {
 		}
 	}
 
+	// If got here but don't have any actual paths, have to return something, otherwise WPE will purge everything
+	if ( empty( $paths ) ) {
+		$paths = [ preg_quote( Settings::graphql_endpoint() . '/' . uniqid('--notreal--') ) ];
+	}
+
 	log( 'WpeGraphql Purge Paths: ' . print_r($paths, 1) );
 
 	return array_unique( $paths );


### PR DESCRIPTION
Was seeing a behavior where when creating a new post, the specific test WP had a plugin during that action loop that would make some graphql queries. These queries would trigger saves in our collection data for the new post node. When the 'save_post' action which our plugin listens for, finally invokes, it sees an entry in our collection for the new node (doesn't know that the node is just created) and proceeds to invoke the wpengine varnish purge.  In the followup actions from the wpengine plugin, our filter to add additional urls actually see not real urls for the new post node, cause it has none yet.  But if we return an empty [][ array from our filter to the wpengine varnish purge function, it has logic to purge all .* for the domain.  We don't want that.  So, this PR at minimal will return a graphql path, that hopefully is random enough not to exist and we purge it.  It's one way to solve the problem.

Reference https://github.com/wp-graphql/wp-graphql-labs/issues/119

